### PR TITLE
Add VS Code–style Activity Bar and Improved File Explorer issue 

### DIFF
--- a/code/public/app.css
+++ b/code/public/app.css
@@ -54,6 +54,41 @@ body {
     flex-direction: row; /* Default to horizontal layout for sidebars */
 }
 
+/* VS Code–like Activity Bar */
+#activity-bar {
+    width: 48px;
+    background-color: #252526;
+    color: #cccccc;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 6px 0;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+#activity-bar .activity-item {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    border-radius: 6px;
+}
+
+#activity-bar .activity-item:hover {
+    background-color: #2d2d30;
+}
+
+#activity-bar .activity-item.active {
+    background-color: #094771;
+    color: #ffffff;
+}
+
 /* NEW: Styles for the tutorial sidebar */
 #tutorial-sidebar {
     width: 250px; /* Initial width */

--- a/code/public/app.js
+++ b/code/public/app.js
@@ -603,19 +603,24 @@ function viewAutosavedFiles() {
   const list = document.getElementById('saved-files-modal-list');
   list.innerHTML = '';
 
+  // Collect and sort file names alphabetically to mimic VS Code ordering
+  const files = [];
   for (let i = 0; i < localStorage.length; i++) {
     const fileName = localStorage.key(i);
     const ext = fileName.split('.').pop().toLowerCase();
-    if (['html', 'css', 'js'].includes(ext)) {
-      const li = document.createElement('li');
-      li.textContent = fileName;
-      li.onclick = () => {
-        loadFile(fileName);
-        closeSavedFilesModal();
-      };
-      list.appendChild(li);
-    }
+    if (['html', 'css', 'js'].includes(ext)) files.push(fileName);
   }
+  files.sort((a, b) => a.localeCompare(b));
+
+  files.forEach((fileName) => {
+    const li = document.createElement('li');
+    li.textContent = fileName;
+    li.onclick = () => {
+      loadFile(fileName);
+      closeSavedFilesModal();
+    };
+    list.appendChild(li);
+  });
 
   if (list.children.length === 0) {
     const li = document.createElement('li');

--- a/code/public/index.html
+++ b/code/public/index.html
@@ -168,7 +168,7 @@
 </head>
 
 <body>
-    <button class="show-explorer-btn" id="show-explorer-btn" onclick="showFileExplorer()">📁 Show Explorer</button>
+    <button class="show-explorer-btn" id="show-explorer-btn" onclick="showFileExplorer()" style="display:none!important;" aria-hidden="true">📁 Show Explorer</button>
 
     <div class="toolbar">
         <div class="button-group">
@@ -233,6 +233,10 @@
     </div>
 
     <div class="main-container" id="main-container">
+        <nav id="activity-bar" aria-label="Activity Bar">
+            <button class="activity-item" id="activity-explorer" title="Explorer" onclick="toggleActivityPanel('explorer')">📁</button>
+            <button class="activity-item active" id="activity-tutorials" title="Tutorials" onclick="toggleActivityPanel('tutorials')">📘</button>
+        </nav>
         <aside id="tutorial-sidebar">
             <div class="sidebar-header">
                 <h3>Step-by-Step Tutorial</h3>
@@ -243,7 +247,7 @@
             </div>
         </aside>
 
-        <div class="file-explorer" id="file-explorer">
+        <div class="file-explorer hidden" id="file-explorer">
             <div class="file-explorer-header">
                 <h3>File Explorer</h3>
                 <button class="file-explorer-toggle" onclick="hideFileExplorer()">✕</button>
@@ -421,7 +425,9 @@
         function displayRepos(repos) {
             const reposDiv = document.getElementById('github-repos');
             reposDiv.innerHTML = '';
-            repos.forEach((repo, i) => {
+            // Alphabetical sort like VS Code
+            const sorted = [...repos].sort((a, b) => a.full_name.localeCompare(b.full_name));
+            sorted.forEach((repo, i) => {
                 const btn = document.createElement('button');
                 btn.textContent = `${i + 1}. ${repo.full_name}`;
                 btn.onclick = () => {
@@ -455,8 +461,9 @@
             }).then(res => res.json()).then(files => {
                 const filesDiv = document.getElementById('github-files');
                 filesDiv.innerHTML = '';
-                files.forEach(file => {
-                    if (file.name.endsWith('.html') || file.name.endsWith('.css') || file.name.endsWith('.js')) {
+                const filtered = files.filter(file => file.name.endsWith('.html') || file.name.endsWith('.css') || file.name.endsWith('.js'));
+                filtered.sort((a, b) => a.name.localeCompare(b.name));
+                filtered.forEach(file => {
                         const btn = document.createElement('button');
                         btn.textContent = file.name;
                         btn.onclick = () => loadGitHubFile({
@@ -467,7 +474,6 @@
                             repo: repo.name
                         });
                         filesDiv.appendChild(btn);
-                    }
                 });
             }).catch(err => {
                 console.error('Error fetching files:', err);
@@ -525,20 +531,26 @@
             const fileExplorer = document.getElementById('file-explorer');
             const mainContainer = document.getElementById('main-container');
             const showBtn = document.getElementById('show-explorer-btn');
+            const activityBtn = document.getElementById('activity-explorer');
             
             fileExplorer.classList.add('hidden');
             mainContainer.classList.add('full-width');
-            showBtn.style.display = 'block';
+            // Keep the legacy button hidden so it doesn't fight with the activity bar
+            showBtn.style.display = 'none';
+            if (activityBtn) activityBtn.classList.remove('active');
         }
 
         function showFileExplorer() {
             const fileExplorer = document.getElementById('file-explorer');
             const mainContainer = document.getElementById('main-container');
             const showBtn = document.getElementById('show-explorer-btn');
+            const activityBtn = document.getElementById('activity-explorer');
             
             fileExplorer.classList.remove('hidden');
             mainContainer.classList.remove('full-width');
+            // Ensure legacy button stays hidden
             showBtn.style.display = 'none';
+            if (activityBtn) activityBtn.classList.add('active');
         }
         
         // This window.onload is handled by the combined DOMContentLoaded in app.js now.
@@ -614,6 +626,36 @@
                 }
             } catch (err) {
                 alert('❌ Error updating file: ' + err.message);
+            }
+        }
+
+        // VS Code–style activity bar toggle
+        function toggleActivityPanel(panel) {
+            const explorer = document.getElementById('file-explorer');
+            const explorerBtn = document.getElementById('activity-explorer');
+            const tutorialSidebar = document.getElementById('tutorial-sidebar');
+            const tutorialBtn = document.getElementById('activity-tutorials');
+
+            if (panel === 'explorer') {
+                if (explorer.classList.contains('hidden')) {
+                    showFileExplorer();
+                    explorerBtn.classList.add('active');
+                } else {
+                    hideFileExplorer();
+                    explorerBtn.classList.remove('active');
+                }
+                return;
+            }
+
+            if (panel === 'tutorials') {
+                const isHidden = tutorialSidebar.classList.contains('hidden');
+                if (isHidden) {
+                    tutorialSidebar.classList.remove('hidden');
+                    tutorialBtn.classList.add('active');
+                } else {
+                    tutorialSidebar.classList.add('hidden');
+                    tutorialBtn.classList.remove('active');
+                }
             }
         }
 


### PR DESCRIPTION
feat(ui): add VS Code–style Activity Bar; fix Explorer/Git overlap
     Move File Explorer to a sidebar next to tutorial-sidebar; hidden by default
     Add Activity Bar with Explorer (📁) and Tutorials (📘) toggles
    Keep legacy “Show Explorer” button hidden to avoid conflicts
    Prevent Explorer from overriding GitHub login/logout buttons
    Sort GitHub repos, repo files, and saved files alphabetically
    Preserve existing features; no breaking changes
Why:
   Improves UX with a familiar VS Code layout
    Resolves UI bug blocking GitHub auth controls
    Makes navigation predictable and boosts productivity